### PR TITLE
Update webhook.ts

### DIFF
--- a/src/lib/webhook/webhook.ts
+++ b/src/lib/webhook/webhook.ts
@@ -1,22 +1,24 @@
-export default async function sendWebhook(payload: string, url: string): Promise<void> {
+export default async function sendWebhook(url: string, method: 'GET' | 'POST' = 'POST', payload?: string): Promise<void> {
     if (!url) {
         console.error('Webhook error: URL is required')
         return
     }
 
-    const requestHeaders = {
-        'Content-Type': 'application/json',
-    }
-
     try {
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), 5000)
-        const response = await fetch(url, {
-            method: 'POST',
-            headers: requestHeaders,
-            body: payload,
+
+        const fetchOptions: RequestInit = {
+            method,
             signal: controller.signal
-        })
+        }
+
+        if (method === 'POST' && payload) {
+            fetchOptions.headers = { 'Content-Type': 'application/json' }
+            fetchOptions.body = payload
+        }
+
+        const response = await fetch(url, fetchOptions)
 
         clearTimeout(timeoutId)
 


### PR DESCRIPTION
函数参数顺序调整: (payload, url) → (url, method, payload?)

新增 method 参数，支持 'GET' 或 'POST'，默认为 'POST'

payload 改为可选参数

GET 请求时不发送 body 和 Content-Type header